### PR TITLE
Fix recursive call when using companion extension

### DIFF
--- a/flow-operators/src/commonMain/kotlin/com/skydoves/flow/operators/onetime/OnetimeStateIn.kt
+++ b/flow-operators/src/commonMain/kotlin/com/skydoves/flow/operators/onetime/OnetimeStateIn.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.transformLatest
+import kotlin.time.Duration
 
 /**
  * Create an upstream cold flow as a StateFlow that triggers the upstream operation only once,
@@ -69,21 +70,21 @@ public fun <T> Flow<T>.onetimeStateIn(
  * designed to limit upstream emissions to only once. After the initial emission,
  * it remains inactive until an active subscriber reappears.
  *
- * @param stopTimeout configures a delay (in milliseconds) between the disappearance of the last
+ * @param stopTimeout configures a delay (as [Duration]) between the disappearance of the last
  * subscriber and the stopping of the sharing coroutine. It defaults to zero (stop immediately).
- * @param replayExpiration configures a delay (in milliseconds) between the stopping of
+ * @param replayExpiration configures a delay (as [Duration]) between the stopping of
  * the sharing coroutine and the resetting of the replay cache (which makes the cache empty for the
  * [shareIn] operator and resets the cached value to the original `initialValue`
  * for the [stateIn] operator). It defaults to `Long.MAX_VALUE` (keep replay cache forever,
  * never reset buffer). Use zero value to expire the cache immediately.
  */
 public fun SharingStarted.Companion.OnetimeWhileSubscribed(
-  stopTimeout: Long,
-  replayExpiration: Long = Long.MAX_VALUE,
+  stopTimeout: Duration,
+  replayExpiration: Duration = Duration.INFINITE,
 ): OnetimeWhileSubscribed {
   return OnetimeWhileSubscribed(
-    stopTimeout = stopTimeout,
-    replayExpiration = replayExpiration,
+    stopTimeout = stopTimeout.inWholeMilliseconds,
+    replayExpiration = replayExpiration.inWholeMilliseconds,
   )
 }
 


### PR DESCRIPTION
### 🎯 Goal

Resolves an issue where using the companion extension for `OnetimeWhileSubscribed` fails due to recursive calls to itself.
Illustrated by the IDE in line 84:

![image](https://github.com/user-attachments/assets/c7bbddc3-6801-473c-ab00-377fa13e6da7)

### 🛠 Implementation details

The companion extension uses Kotlin's `Duration` for the `stopTimeout` and the `replayExpiration`. On the one hand, this resolves the issue, and on the other it provides an extension that is similar to those of the Kotlin library:

```kotlin
public fun SharingStarted.Companion.WhileSubscribed(
    stopTimeout: Duration = Duration.ZERO,
    replayExpiration: Duration = Duration.INFINITE
): SharingStarted =
    StartedWhileSubscribed(stopTimeout.inWholeMilliseconds, replayExpiration.inWholeMilliseconds)
```

### ✍️ Explain examples

I don't think any examples are needed 😁

### Preparing a pull request for review

Ensure your change is properly formatted by running:

```bash
$ ./gradlew spotlessApply
```

✅ Passed

Then dump binary APIs of this library that is public in sense of Kotlin visibilities and ensures that the public binary API wasn't changed in a way that makes this change binary incompatible.

```bash
./gradlew apiDump
```

⚠️ Failed on my machine with an exception:

```
Execution failed for task ':flow-operators:compileReleaseKotlinAndroid'.
> Inconsistent JVM-target compatibility detected for tasks 'compileReleaseJavaWithJavac' (17) and 'compileReleaseKotlinAndroid' (21).

  Consider using JVM Toolchain: https://kotl.in/gradle/jvm/toolchain
  Learn more about JVM-target validation: https://kotl.in/gradle/jvm/target-validation
```

## Code reviews

All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose. Consult [GitHub Help](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) for more information on using pull requests.
